### PR TITLE
Enable float64 precision

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Run tests
-        run: uv run python -m pytest tests --cov --cov-config=pyproject.toml --cov-report=xml
+        run: make test
+
+      - name: Run tests float64
+        run: JAX_ENABLE_X64=1 make test
 
       - name: Check typing
         run: uv run mypy

--- a/gmmx/gmm.py
+++ b/gmmx/gmm.py
@@ -94,10 +94,6 @@ class Axis(int, Enum):
 
 def check_shape(array: jax.Array, expected: tuple[int | None, ...]) -> None:
     """Check shape of array"""
-    # if array.dtype != jnp.float32:
-    #     message = f"Expected float32, got {array.dtype}"
-    #     raise ValueError(message)
-
     if len(array.shape) != len(expected):
         message = f"Expected shape {expected}, got {array.shape}"
         raise ValueError(message)
@@ -1023,7 +1019,7 @@ class GaussianMixtureSKLearn:
             self._gmm = GaussianMixtureModelJax.from_squeezed(
                 means=self.means_init,  # type: ignore [arg-type]
                 covariances=covar.from_precisions(
-                    self.precisions_init  # .astype(np.float32)  # type: ignore [union-attr]
+                    self.precisions_init  # type: ignore [union-attr]
                 ).values_numpy,
                 weights=self.weights_init,  # type: ignore [arg-type]
                 covariance_type=self.covariance_type,

--- a/gmmx/gmm.py
+++ b/gmmx/gmm.py
@@ -1018,9 +1018,7 @@ class GaussianMixtureSKLearn:
 
             self._gmm = GaussianMixtureModelJax.from_squeezed(
                 means=self.means_init,  # type: ignore [arg-type]
-                covariances=covar.from_precisions(
-                    self.precisions_init  # type: ignore [union-attr]
-                ).values_numpy,
+                covariances=covar.from_precisions(self.precisions_init).values_numpy,
                 weights=self.weights_init,  # type: ignore [arg-type]
                 covariance_type=self.covariance_type,
             )

--- a/gmmx/gmm.py
+++ b/gmmx/gmm.py
@@ -94,9 +94,9 @@ class Axis(int, Enum):
 
 def check_shape(array: jax.Array, expected: tuple[int | None, ...]) -> None:
     """Check shape of array"""
-    if array.dtype != jnp.float32:
-        message = f"Expected float32, got {array.dtype}"
-        raise ValueError(message)
+    # if array.dtype != jnp.float32:
+    #     message = f"Expected float32, got {array.dtype}"
+    #     raise ValueError(message)
 
     if len(array.shape) != len(expected):
         message = f"Expected shape {expected}, got {array.shape}"
@@ -1023,7 +1023,7 @@ class GaussianMixtureSKLearn:
             self._gmm = GaussianMixtureModelJax.from_squeezed(
                 means=self.means_init,  # type: ignore [arg-type]
                 covariances=covar.from_precisions(
-                    self.precisions_init.astype(np.float32)  # type: ignore [union-attr]
+                    self.precisions_init  # .astype(np.float32)  # type: ignore [union-attr]
                 ).values_numpy,
                 weights=self.weights_init,  # type: ignore [arg-type]
                 covariance_type=self.covariance_type,


### PR DESCRIPTION
This PR addresses #10, by removing the dtype check and adding unit tests.